### PR TITLE
Add an action to get rack params

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -17,6 +17,7 @@ inputs:
       - env-set
       - find-release
       - get-scale
+      - get-rack-param
       - login
       - login-user
       - promote
@@ -49,7 +50,7 @@ inputs:
     description: Use a custom path for your convox.yml
     required: false
   paramName:
-    description: Name of the parameter to set
+    description: Name of the parameter to get or set
   paramValue:
     description: Value of the parameter to set
   release:

--- a/action.yml
+++ b/action.yml
@@ -75,6 +75,8 @@ outputs:
     description: CPU scale value
   memory:
     description: Memory scale value
+  param_value:
+    description: Rack parameter value
   scaling_event:
     description: Boolean value to indicate if a scaling event is in progress
 runs:

--- a/action.yml
+++ b/action.yml
@@ -75,8 +75,6 @@ outputs:
     description: CPU scale value
   memory:
     description: Memory scale value
-  param_value:
-    description: Rack parameter value
   scaling_event:
     description: Boolean value to indicate if a scaling event is in progress
 runs:

--- a/entrypoint-get-rack-param.sh
+++ b/entrypoint-get-rack-param.sh
@@ -3,8 +3,8 @@ set -x
 
 export CONVOX_RACK=$INPUT_RACK
 
-echo "Retrieving $RACK_PARAM for $CONVOX_RACK"
-output=$(convox rack params | awk -v param="$RACK_PARAM" '$1 == param {print $2}')
+echo "Retrieving $INPUT_PARAMNAME for $CONVOX_RACK"
+output=$(convox rack params | awk -v param="$INPUT_PARAMNAME" '$1 == param {print $2}')
 
 echo "PARAM_VALUE=$output" >> $GITHUB_OUTPUT
 echo "PARAM_VALUE=$output" >> $GITHUB_ENV

--- a/entrypoint-get-rack-param.sh
+++ b/entrypoint-get-rack-param.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+set -x
+
+export CONVOX_RACK=$INPUT_RACK
+
+echo "Retrieving $RACK_PARAM for $CONVOX_RACK"
+output=$(convox rack params | awk -v param="$RACK_PARAM" '$1 == param {print $2}')
+
+echo "PARAM_VALUE=$output" >> $GITHUB_OUTPUT
+echo "PARAM_VALUE=$output" >> $GITHUB_ENV

--- a/entrypoint-rack-param.sh
+++ b/entrypoint-rack-param.sh
@@ -5,3 +5,6 @@ export CONVOX_RACK=$INPUT_RACK
 
 echo "Running rack params set on $INPUT_RACK for param $INPUT_PARAMNAME"
 convox rack params set $INPUT_PARAMNAME=$INPUT_PARAMVALUE
+
+echo "PARAM_VALUE=$output" >> $GITHUB_OUTPUT
+echo "PARAM_VALUE=$output" >> $GITHUB_ENV

--- a/entrypoint-rack-param.sh
+++ b/entrypoint-rack-param.sh
@@ -5,6 +5,3 @@ export CONVOX_RACK=$INPUT_RACK
 
 echo "Running rack params set on $INPUT_RACK for param $INPUT_PARAMNAME"
 convox rack params set $INPUT_PARAMNAME=$INPUT_PARAMVALUE
-
-echo "PARAM_VALUE=$output" >> $GITHUB_OUTPUT
-echo "PARAM_VALUE=$output" >> $GITHUB_ENV

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -37,6 +37,9 @@ case "$value" in
   "get-scale")
     /entrypoint-get-scale.sh
     ;;
+  "get-rack-param")
+    /entrypoint-get-rack-param.sh
+    ;;
   "login")
     /entrypoint-login.sh
     ;;


### PR DESCRIPTION
This would let us make decisions in GH actions based on the params of the rack that we're deploying something to (thinking of rack region affecting the instance type in the convox.yml, particularly).