### PR TITLE
Add review-app lifecycle actions (env-copy, app-param); idempotent create/destroy

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Multiple Convox CLI commands in one slim composite GitHub Action. Instead of usi
 
 ## Supported Actions
 
-`login` · `login-user` · `build` · `build-migrate` · `deploy` · `create` · `destroy` · `promote` · `rollback` · `run` · `scale` · `get-scale` · `env-set` · `find-build` · `find-release` · `get-rack-param` · `rack-param`
+`login` · `login-user` · `build` · `build-migrate` · `deploy` · `create` · `destroy` · `promote` · `rollback` · `run` · `scale` · `get-scale` · `env-set` · `env-copy` · `app-param` · `find-build` · `find-release` · `get-rack-param` · `rack-param`
 
 ## Quick Start
 
@@ -52,6 +52,8 @@ Multiple Convox CLI commands in one slim composite GitHub Action. Instead of usi
 | `manifest` | Custom path for convox.yml | No | — |
 | `paramName` | Rack parameter name | For `get-rack-param`, `rack-param` | — |
 | `paramValue` | Rack parameter value | For `rack-param` | — |
+| `params` | App params as `Key1=value1 Key2=value2`, or newline-separated pairs when values contain spaces | For `app-param` | — |
+| `exclude` | Env var names to omit when copying (space- or newline-separated) | No (`env-copy`) | — |
 | `release` | Release ID (auto-detected from prior build step if omitted) | For `promote`, `rollback` | — |
 | `service` | Service name | For `run`, `scale`, `get-scale` | — |
 | `command` | Command to run | For `run` | — |
@@ -73,6 +75,8 @@ Multiple Convox CLI commands in one slim composite GitHub Action. Instead of usi
 | `PENDING_PROCESSES` | Count of pending processes | `get-scale` |
 | `UNHEALTHY_PROCESSES` | Count of unhealthy processes | `get-scale` |
 | `PARAM_VALUE` | Rack parameter value | `get-rack-param` |
+| `CREATED` | `true` if the app was created by this step, `false` if it already existed | `create` |
+| `DESTROYED` | `true` if the app was deleted by this step, `false` if it did not exist | `destroy` |
 
 Outputs are available via `steps.<id>.outputs.<NAME>`; they are no longer exported as environment variables (v3.x behaviour change). The one exception is `RELEASE`, which is still exported to the environment so `promote` and `rollback` can auto-detect it from a prior `build` step.
 
@@ -148,19 +152,26 @@ Exports a build from one app/rack and imports it to another.
 
 ### create
 
-Creates a new Convox app.
+Creates a Convox app. Idempotent — if the app already exists the step is a
+no-op. The `CREATED` output is `true` only when this step created the app, so
+you can run one-time setup (such as `app-param`) only on first creation.
 
 ```yaml
 - uses: beastawakens/action-convox-multi-slim@v3
+  id: create
   with:
     action: create
     rack: my-rack
     app: my-new-app
+
+- if: steps.create.outputs.CREATED == 'true'
+  run: echo "First deploy — app was just created"
 ```
 
 ### destroy
 
-Deletes a Convox app.
+Deletes a Convox app. Idempotent — if the app does not exist the step is a
+no-op. The `DESTROYED` output reflects whether a deletion actually happened.
 
 ```yaml
 - uses: beastawakens/action-convox-multi-slim@v3
@@ -168,6 +179,36 @@ Deletes a Convox app.
     action: destroy
     rack: my-rack
     app: my-app
+```
+
+### app-param
+
+Sets one or more app parameters (for example build resources).
+
+```yaml
+- uses: beastawakens/action-convox-multi-slim@v3
+  with:
+    action: app-param
+    rack: my-rack
+    app: my-app
+    params: "BuildCpu=2000 BuildMem=4096"
+```
+
+### env-copy
+
+Copies the environment of one app onto another, optionally excluding keys. The
+env is streamed source → destination without being printed, logged, or exposed
+as an output. Useful for seeding an ephemeral app from a base app while dropping
+values that should differ (e.g. datastore URLs).
+
+```yaml
+- uses: beastawakens/action-convox-multi-slim@v3
+  with:
+    action: env-copy
+    rack: my-rack
+    app: base-app                # source
+    destinationApp: my-pr-app     # destination (destinationRack defaults to rack)
+    exclude: "DATABASE_URL REDIS_URL"
 ```
 
 ### promote

--- a/action.yml
+++ b/action.yml
@@ -6,9 +6,10 @@ color: blue
 inputs:
   action:
     description: >-
-      Convox command to run. One of: build, build-migrate, create, deploy,
-      destroy, env-set, find-build, find-release, get-scale, get-rack-param,
-      login, login-user, promote, rack-param, rollback, run, scale
+      Convox command to run. One of: app-param, build, build-migrate, create,
+      deploy, destroy, env-copy, env-set, find-build, find-release, get-scale,
+      get-rack-param, login, login-user, promote, rack-param, rollback, run,
+      scale
     required: true
   password:
     description: Convox deploy key value
@@ -58,10 +59,21 @@ inputs:
     description: The number of instances to scale to
   env:
     description: Environment variables in the form 'key1=value1 key2=value2', or newline-separated pairs when values contain spaces
+  exclude:
+    description: (env-copy) Space- or newline-separated list of env var names to omit when copying from the source app
+    required: false
+  params:
+    description: (app-param) App parameters to set in the form 'Key1=value1 Key2=value2', or newline-separated pairs when values contain spaces
 outputs:
   BUILD:
     description: Build ID of the build matching the description
     value: ${{ steps.convox-action.outputs.BUILD }}
+  CREATED:
+    description: (create) "true" if the app was created by this step, "false" if it already existed
+    value: ${{ steps.convox-action.outputs.CREATED }}
+  DESTROYED:
+    description: (destroy) "true" if the app was deleted by this step, "false" if it did not exist
+    value: ${{ steps.convox-action.outputs.DESTROYED }}
   RELEASE:
     description: Release ID of the created build
     value: ${{ steps.convox-action.outputs.RELEASE }}

--- a/entrypoint-app-param.sh
+++ b/entrypoint-app-param.sh
@@ -1,0 +1,42 @@
+#!/bin/sh
+set -e
+. "$(cd "$(dirname "$0")" && pwd)/lib/common.sh"
+
+# Set one or more app parameters (e.g. BuildCpu, BuildMem). INPUT_PARAMS is a
+# space- or newline-separated list of KEY=VALUE pairs; newline separation lets
+# a value contain spaces (mirrors env-set).
+require_input "INPUT_APP" "$INPUT_APP"
+require_input "INPUT_PARAMS" "$INPUT_PARAMS"
+set_rack
+
+echo "Setting app params for $INPUT_APP on $CONVOX_RACK"
+
+nl=$(printf '\n_'); nl=${nl%_}
+case "$INPUT_PARAMS" in
+  *"$nl"*)
+    old_ifs="$IFS"
+    IFS="$(printf '\n_')"; IFS="${IFS%_}"   # IFS = newline only
+    set -f
+    # shellcheck disable=SC2086
+    set -- $INPUT_PARAMS
+    set +f
+    IFS="$old_ifs"
+    ;;
+  *)
+    set -f
+    # shellcheck disable=SC2086
+    set -- $INPUT_PARAMS
+    set +f
+    ;;
+esac
+
+# Drop empty arguments produced by blank/trailing lines
+old_argc=$#
+i=0
+while [ "$i" -lt "$old_argc" ]; do
+  pair="$1"; shift
+  if [ -n "$pair" ]; then set -- "$@" "$pair"; fi
+  i=$((i+1))
+done
+
+convox apps params set "$@" -a "$INPUT_APP" --rack "$CONVOX_RACK"

--- a/entrypoint-create.sh
+++ b/entrypoint-create.sh
@@ -5,5 +5,14 @@ set -e
 require_input "INPUT_APP" "$INPUT_APP"
 set_rack
 
-echo "Creating App $INPUT_APP on $CONVOX_RACK"
-convox apps create "$INPUT_APP" --rack "$CONVOX_RACK" --wait
+# Idempotent: skip creation if the app already exists (so re-runs don't fail).
+# CREATED output is "true" only when this step created the app, letting callers
+# run one-time setup (e.g. app params) only on first creation.
+if convox apps info "$INPUT_APP" --rack "$CONVOX_RACK" >/dev/null 2>&1; then
+  echo "App $INPUT_APP already exists on $CONVOX_RACK"
+  write_output "CREATED" "false"
+else
+  echo "Creating App $INPUT_APP on $CONVOX_RACK"
+  convox apps create "$INPUT_APP" --rack "$CONVOX_RACK" --wait
+  write_output "CREATED" "true"
+fi

--- a/entrypoint-destroy.sh
+++ b/entrypoint-destroy.sh
@@ -5,5 +5,14 @@ set -e
 require_input "INPUT_APP" "$INPUT_APP"
 set_rack
 
-echo "Destroying App $INPUT_APP on $CONVOX_RACK"
-convox apps delete "$INPUT_APP" --rack "$CONVOX_RACK" --wait
+# Idempotent: only delete if the app exists, so tearing down a PR that never
+# had an app is a no-op rather than an error. DESTROYED output reflects whether
+# a deletion actually happened.
+if convox apps info "$INPUT_APP" --rack "$CONVOX_RACK" >/dev/null 2>&1; then
+  echo "Destroying App $INPUT_APP on $CONVOX_RACK"
+  convox apps delete "$INPUT_APP" --rack "$CONVOX_RACK" --wait
+  write_output "DESTROYED" "true"
+else
+  echo "App $INPUT_APP does not exist on $CONVOX_RACK; nothing to destroy"
+  write_output "DESTROYED" "false"
+fi

--- a/entrypoint-env-copy.sh
+++ b/entrypoint-env-copy.sh
@@ -1,0 +1,45 @@
+#!/bin/sh
+set -e
+. "$(cd "$(dirname "$0")" && pwd)/lib/common.sh"
+
+# Copy the environment of one app onto another, optionally excluding some keys.
+# Source app: INPUT_APP / INPUT_RACK. Destination: INPUT_DESTINATIONAPP /
+# INPUT_DESTINATIONRACK (defaults to the source rack). INPUT_EXCLUDE is a
+# space- or newline-separated list of keys to drop (matched as whole names).
+#
+# The env is streamed source -> dest via a temp file that never leaves the
+# runner's temp dir, so secrets are never printed, logged, or exposed as an
+# output.
+require_input "INPUT_APP" "$INPUT_APP"
+require_input "INPUT_DESTINATIONAPP" "$INPUT_DESTINATIONAPP"
+set_rack
+
+dest_rack="${INPUT_DESTINATIONRACK:-$CONVOX_RACK}"
+echo "Copying env from $INPUT_APP ($CONVOX_RACK) to $INPUT_DESTINATIONAPP ($dest_rack)"
+
+tmp=$(mktemp)
+# shellcheck disable=SC2064
+trap "rm -f \"$tmp\"" EXIT
+convox env -a "$INPUT_APP" --rack "$CONVOX_RACK" > "$tmp"
+if [ ! -s "$tmp" ]; then
+  echo "::error::No environment retrieved from source app $INPUT_APP"
+  exit 1
+fi
+
+# Build grep -v arguments from the exclude list (match KEY= at line start).
+set -f
+# shellcheck disable=SC2086
+set -- $INPUT_EXCLUDE
+set +f
+grep_args=""
+for key in "$@"; do
+  [ -n "$key" ] || continue
+  grep_args="$grep_args -e ^${key}="
+done
+
+if [ -n "$grep_args" ]; then
+  # shellcheck disable=SC2086
+  grep -v $grep_args "$tmp" | convox env set -a "$INPUT_DESTINATIONAPP" --rack "$dest_rack"
+else
+  convox env set -a "$INPUT_DESTINATIONAPP" --rack "$dest_rack" < "$tmp"
+fi

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -28,6 +28,12 @@ case "$value" in
   "destroy")
     "$ACTION_DIR/entrypoint-destroy.sh"
     ;;
+  "app-param")
+    "$ACTION_DIR/entrypoint-app-param.sh"
+    ;;
+  "env-copy")
+    "$ACTION_DIR/entrypoint-env-copy.sh"
+    ;;
   "env-set")
     "$ACTION_DIR/entrypoint-env-set.sh"
     ;;

--- a/tests/entrypoints.bats
+++ b/tests/entrypoints.bats
@@ -21,7 +21,9 @@ teardown() {
 # ---------------------------------------------------------------------------
 
 @test "dispatcher routes create to convox apps create" {
-  stub_convox 'exit 0'
+  # create is idempotent: it only runs `apps create` when `apps info` shows the
+  # app is absent, so the stub must report the app as not found.
+  stub_convox 'if [ "$1 $2" = "apps info" ]; then exit 1; fi; exit 0'
   export INPUT_ACTION="create"
   export INPUT_APP="my-app"
   export INPUT_RACK="my-rack"
@@ -493,4 +495,162 @@ exit 1'
   [ "$status" -eq 0 ]
   grep -q "BUILD=" "$GITHUB_OUTPUT"
   ! grep -q "BUILD=" "$GITHUB_ENV"
+}
+
+# ---------------------------------------------------------------------------
+# entrypoint-create.sh — idempotent create + CREATED output
+# ---------------------------------------------------------------------------
+
+@test "create: creates the app and reports CREATED=true when it is absent" {
+  stub_convox 'if [ "$1 $2" = "apps info" ]; then exit 1; fi; exit 0'
+  export INPUT_APP="my-app"
+  export INPUT_RACK="my-rack"
+
+  run sh entrypoint-create.sh
+
+  [ "$status" -eq 0 ]
+  grep -q "^apps create my-app" "$CONVOX_CALLS"
+  grep -q "^CREATED=true$" "$GITHUB_OUTPUT"
+}
+
+@test "create: skips creation and reports CREATED=false when the app exists" {
+  stub_convox 'if [ "$1 $2" = "apps info" ]; then exit 0; fi; exit 0'
+  export INPUT_APP="my-app"
+  export INPUT_RACK="my-rack"
+
+  run sh entrypoint-create.sh
+
+  [ "$status" -eq 0 ]
+  ! grep -q "^apps create" "$CONVOX_CALLS"
+  grep -q "^CREATED=false$" "$GITHUB_OUTPUT"
+}
+
+# ---------------------------------------------------------------------------
+# entrypoint-destroy.sh — idempotent destroy + DESTROYED output
+# ---------------------------------------------------------------------------
+
+@test "destroy: deletes the app with --wait and reports DESTROYED=true when it exists" {
+  stub_convox 'if [ "$1 $2" = "apps info" ]; then exit 0; fi; exit 0'
+  export INPUT_APP="my-app"
+  export INPUT_RACK="my-rack"
+
+  run sh entrypoint-destroy.sh
+
+  [ "$status" -eq 0 ]
+  grep -q "^apps delete my-app --rack my-rack --wait$" "$CONVOX_CALLS"
+  grep -q "^DESTROYED=true$" "$GITHUB_OUTPUT"
+}
+
+@test "destroy: is a no-op reporting DESTROYED=false when the app is absent" {
+  stub_convox 'if [ "$1 $2" = "apps info" ]; then exit 1; fi; exit 0'
+  export INPUT_APP="my-app"
+  export INPUT_RACK="my-rack"
+
+  run sh entrypoint-destroy.sh
+
+  [ "$status" -eq 0 ]
+  ! grep -q "^apps delete" "$CONVOX_CALLS"
+  grep -q "^DESTROYED=false$" "$GITHUB_OUTPUT"
+}
+
+# ---------------------------------------------------------------------------
+# entrypoint-app-param.sh
+# ---------------------------------------------------------------------------
+
+@test "dispatcher routes app-param to convox apps params set" {
+  stub_convox 'exit 0'
+  export INPUT_ACTION="app-param"
+  export INPUT_APP="my-app"
+  export INPUT_RACK="my-rack"
+  export INPUT_PARAMS="BuildCpu=2000 BuildMem=4096"
+
+  run sh entrypoint.sh
+
+  [ "$status" -eq 0 ]
+  grep -q "apps params set BuildCpu=2000 BuildMem=4096 -a my-app --rack my-rack" "$CONVOX_CALLS"
+}
+
+@test "app-param: newline-separated form keeps a spaced value as one argument" {
+  stub_convox 'echo "argc=$#" >> "$CONVOX_CALLS"'
+  export INPUT_APP="my-app"
+  export INPUT_RACK="my-rack"
+  export INPUT_PARAMS="$(printf 'BuildCpu=2000\nBuildLabels=convox.io/label=platform tier=spot')"
+
+  run sh entrypoint-app-param.sh
+
+  [ "$status" -eq 0 ]
+  # argv is: apps params set BuildCpu=2000 "BuildLabels=..." -a my-app --rack my-rack = 9 args
+  grep -q "^argc=9$" "$CONVOX_CALLS"
+  grep -F -q "BuildLabels=convox.io/label=platform tier=spot" "$CONVOX_CALLS"
+}
+
+# ---------------------------------------------------------------------------
+# entrypoint-env-copy.sh
+# ---------------------------------------------------------------------------
+
+# convox env (read) prints three vars; convox env set records its stdin so the
+# test can assert which vars were copied through.
+stub_env_copy() {
+  export ENV_SET_STDIN="$BATS_TEST_TMPDIR/env-set-stdin"
+  stub_convox '
+if [ "$1" = "env" ] && [ "$2" = "set" ]; then cat >> "$ENV_SET_STDIN"; exit 0; fi
+if [ "$1" = "env" ]; then printf "A=1\nSANDBOX_DATABASE_URL=postgres://secret\nB=2\n"; exit 0; fi
+exit 0'
+}
+
+@test "env-copy: copies all vars when no exclude is given" {
+  stub_env_copy
+  export INPUT_APP="source-app"
+  export INPUT_DESTINATIONAPP="dest-app"
+  export INPUT_RACK="my-rack"
+
+  run sh entrypoint-env-copy.sh
+
+  [ "$status" -eq 0 ]
+  grep -q "^A=1$" "$ENV_SET_STDIN"
+  grep -q "^SANDBOX_DATABASE_URL=" "$ENV_SET_STDIN"
+  grep -q "^B=2$" "$ENV_SET_STDIN"
+}
+
+@test "env-copy: drops excluded keys" {
+  stub_env_copy
+  export INPUT_APP="source-app"
+  export INPUT_DESTINATIONAPP="dest-app"
+  export INPUT_RACK="my-rack"
+  export INPUT_EXCLUDE="SANDBOX_DATABASE_URL"
+
+  run sh entrypoint-env-copy.sh
+
+  [ "$status" -eq 0 ]
+  grep -q "^A=1$" "$ENV_SET_STDIN"
+  grep -q "^B=2$" "$ENV_SET_STDIN"
+  ! grep -q "^SANDBOX_DATABASE_URL=" "$ENV_SET_STDIN"
+}
+
+@test "env-copy: fails when the source app has no env" {
+  stub_convox '
+if [ "$1" = "env" ] && [ "$2" = "set" ]; then cat > /dev/null; exit 0; fi
+if [ "$1" = "env" ]; then exit 0; fi
+exit 0'
+  export INPUT_APP="source-app"
+  export INPUT_DESTINATIONAPP="dest-app"
+  export INPUT_RACK="my-rack"
+
+  run sh entrypoint-env-copy.sh
+
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"No environment retrieved"* ]]
+}
+
+@test "dispatcher routes env-copy to entrypoint-env-copy.sh" {
+  stub_env_copy
+  export INPUT_ACTION="env-copy"
+  export INPUT_APP="source-app"
+  export INPUT_DESTINATIONAPP="dest-app"
+  export INPUT_RACK="my-rack"
+
+  run sh entrypoint.sh
+
+  [ "$status" -eq 0 ]
+  grep -q "^A=1$" "$ENV_SET_STDIN"
 }


### PR DESCRIPTION
## Summary

Adds the app-lifecycle and env operations the Smile ID Portal needs for user-driven review apps, so a caller can create, seed, deploy, and tear down a per-PR app using only this action (no raw convox CLI in the workflow).

## Adds

- `app-param`: sets one or more app parameters (e.g. `BuildCpu`, `BuildMem`) via `convox apps params set`. Takes `params` as space- or newline-separated `Key=value` pairs (newline form allows spaces in a value).
- `env-copy`: copies one app's environment onto another, with an optional `exclude` list of keys to drop. The env is streamed source → destination without being printed, logged, or exposed as an output.

## Improves

- `create` is now idempotent (no-op if the app already exists) and emits a `CREATED` output — `true` only when this step created the app, so callers can run one-time setup (like `app-param`) only on first creation.
- `destroy` is now idempotent (no-op if the app is absent) and emits a `DESTROYED` output.

## Known Issues

- `create`/`destroy` behaviour change: they no longer error when the app already exists / is already gone. This is a safe superset for existing callers, but noting it for the minor bump.

## Test Instructions

- `shellcheck -x entrypoint*.sh lib/common.sh tests/helpers.bash` — clean.
- `bats tests/` — 59 passing (added coverage for both new actions, idempotent create/destroy with their outputs, and env-copy exclude filtering).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013TjBbJeEWjd7yFCMUu2iXF
