### PR TITLE
Wire exclude/params inputs into the run step env block

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -153,3 +153,5 @@ runs:
         INPUT_COMMAND: ${{ inputs.command }}
         INPUT_COUNT: ${{ inputs.count }}
         INPUT_ENV: ${{ inputs.env }}
+        INPUT_EXCLUDE: ${{ inputs.exclude }}
+        INPUT_PARAMS: ${{ inputs.params }}

--- a/tests/entrypoints.bats
+++ b/tests/entrypoints.bats
@@ -654,3 +654,19 @@ exit 0'
   [ "$status" -eq 0 ]
   grep -q "^A=1$" "$ENV_SET_STDIN"
 }
+
+# ---------------------------------------------------------------------------
+# action.yml wiring — guards against declaring an input but forgetting to map
+# it into the run step's env: block (the entrypoint reads INPUT_<UPPER>).
+# ---------------------------------------------------------------------------
+
+@test "action.yml: every declared input is mapped to an INPUT_* env var" {
+  inputs=$(awk '/^inputs:/{f=1;next} /^[a-zA-Z]/{f=0} f && /^  [a-zA-Z]/{sub(/:.*/,"",$1); print $1}' action.yml)
+  [ -n "$inputs" ]  # sanity: we found some inputs
+  missing=""
+  for name in $inputs; do
+    upper=$(printf '%s' "$name" | tr '[:lower:]' '[:upper:]')
+    grep -q "INPUT_${upper}:" action.yml || missing="$missing $name"
+  done
+  [ -z "$missing" ] || { echo "inputs declared but not wired to INPUT_* env:$missing"; false; }
+}


### PR DESCRIPTION
v3.2.0 declared the `exclude` (env-copy) and `params` (app-param) inputs but didn't map them to `INPUT_EXCLUDE`/`INPUT_PARAMS` in the composite run step, so `app-param` failed with "INPUT_PARAMS is required" and `env-copy` silently ignored its exclude list (a data-isolation risk for callers).

Adds both mappings plus a guard test asserting every declared input is wired to an `INPUT_*` env var. shellcheck clean, bats 60/60.

🤖 Generated with [Claude Code](https://claude.com/claude-code)